### PR TITLE
Improve performance of Live pages

### DIFF
--- a/frontend/src/Characters.tsx
+++ b/frontend/src/Characters.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { Helmet } from 'react-helmet-async';
 
 import { CharactersResponse, CharacterInfo } from './types';
-import { useSingleSearchParam } from './hooks';
+import { useSingleSearchParam, useDebouncedValue } from './hooks';
 
 import CharactersTable from './CharactersTable';
 import FilterBar from './FilterBar';
@@ -18,6 +18,7 @@ const Characters: React.FunctionComponent<Props> = ({ data }) => {
   const params = useParams();
   const { factionKey } = params;
   const [filterText, setFilterText] = useSingleSearchParam('search');
+  const debouncedFilterText = useDebouncedValue(filterText, 200);
 
   const charactersByFaction = React.useMemo(() => {
     return data.characters.reduce((map, character) => {
@@ -36,7 +37,7 @@ const Characters: React.FunctionComponent<Props> = ({ data }) => {
     }, [factionKey, data.characters, charactersByFaction]);
 
   const filteredCharacters = React.useMemo(() => {
-    const filterTextForSearching = filterText.toLowerCase().trim();
+    const filterTextForSearching = debouncedFilterText.toLowerCase().trim();
     const filtered = filterTextForSearching.length === 0
       ? characters
       : characters.filter(character =>
@@ -46,7 +47,7 @@ const Characters: React.FunctionComponent<Props> = ({ data }) => {
             || character.factions.some(f => f.name.toLowerCase().includes(filterTextForSearching))
         )
       return filtered;
-  }, [characters, filterText]);
+  }, [characters, debouncedFilterText]);
 
   const factionInfoMap = React.useMemo(() => {
     return Object.fromEntries(data.factions.map(info => [info.key, info]));

--- a/frontend/src/Live.tsx
+++ b/frontend/src/Live.tsx
@@ -5,17 +5,17 @@ import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { LiveResponse, CharactersResponse } from './types';
 import { factionsFromLive, ignoredFactions } from './utils'
 import { useSingleSearchParam, useDebouncedValue } from './hooks';
+import { useLoading, isSuccess } from './LoadingState';
 
 import StreamList from './StreamList';
 import FilterBar from './FilterBar';
 
 interface Props {
   live: LiveResponse;
-  characters: CharactersResponse;
   loadTick: number;
 }
 
-const Live: React.FC<Props> = ({ live, characters, loadTick }) => {
+const Live: React.FC<Props> = ({ live, loadTick }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const params = useParams();
@@ -24,6 +24,12 @@ const Live: React.FC<Props> = ({ live, characters, loadTick }) => {
   const debouncedFilterText = useDebouncedValue(filterText, 200);
 
   const filterTextForSearching = debouncedFilterText.toLowerCase().trim();
+
+  const [charactersLoadingState] = useLoading<CharactersResponse>('/api/v2/characters', { needsLoad: filterText.length > 0 });
+
+  const characters = isSuccess(charactersLoadingState)
+    ? charactersLoadingState.data.characters
+    : [];
 
   const factionInfos = factionsFromLive(live);
   const factionInfoMap = Object.fromEntries(factionInfos.map(info => [info.key, info]));

--- a/frontend/src/Live.tsx
+++ b/frontend/src/Live.tsx
@@ -4,7 +4,7 @@ import { useParams, useNavigate, useLocation } from "react-router-dom";
 
 import { LiveResponse, CharactersResponse } from './types';
 import { factionsFromLive, ignoredFactions } from './utils'
-import { useSingleSearchParam } from './hooks';
+import { useSingleSearchParam, useDebouncedValue } from './hooks';
 
 import StreamList from './StreamList';
 import FilterBar from './FilterBar';
@@ -21,7 +21,9 @@ const Live: React.FC<Props> = ({ live, characters, loadTick }) => {
   const params = useParams();
   const { factionKey } = params;
   const [filterText, setFilterText] = useSingleSearchParam('search');
-  const filterTextForSearching = filterText.toLowerCase().trim();
+  const debouncedFilterText = useDebouncedValue(filterText, 200);
+
+  const filterTextForSearching = debouncedFilterText.toLowerCase().trim();
 
   const factionInfos = factionsFromLive(live);
   const factionInfoMap = Object.fromEntries(factionInfos.map(info => [info.key, info]));
@@ -34,7 +36,7 @@ const Live: React.FC<Props> = ({ live, characters, loadTick }) => {
       const streams = live.streams
         .filter(stream => !ignoredFactions.includes(stream.tagFaction))
         .filter(stream => !(stream.tagFactionSecondary && ignoredFactions.includes(stream.tagFactionSecondary)))
-      const filterTextLookup = filterText
+      const filterTextLookup = debouncedFilterText
         .replace(/^\W+|\W+$|[^\w\s]+/g, ' ')
         .replace(/\s+/g, ' ')
         .toLowerCase()

--- a/frontend/src/Live.tsx
+++ b/frontend/src/Live.tsx
@@ -83,7 +83,9 @@ const Live: React.FC<Props> = ({ live, loadTick }) => {
             || character.displayInfo.nicknames.some(n => n.toLowerCase().includes(filterTextForSearching))
             || character.factions.some(f => f.name.toLowerCase().includes(filterTextForSearching))
           )
-        );
+        )
+        // Limit to 50 offline characters to not overwhelm the list
+        .slice(0, 50);
   }, [characters, factionKey, filterTextForSearching, filteredStreams]);
 
   const selectedFaction = factionKey ? factionInfoMap[factionKey] : undefined;

--- a/frontend/src/LiveContainer.tsx
+++ b/frontend/src/LiveContainer.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Helmet } from "react-helmet-async";
 
-import { useLoading, useAutoReloading, isSuccess, isFailure } from './LoadingState';
-import { LiveResponse, CharactersResponse } from './types';
+import { useAutoReloading, isSuccess, isFailure } from './LoadingState';
+import { LiveResponse } from './types';
 import Live from './Live';
 import Error from './Error';
 import Loading from './Loading';
@@ -10,15 +10,6 @@ import Loading from './Loading';
 const LiveContainer: React.FC = () => {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [liveLoadingState, reloadLive, lastLoad] = useAutoReloading<LiveResponse>('/api/v1/live');
-  const [charactersLoadingState, reloadCharacters] = useLoading<CharactersResponse>('/api/v2/characters');
-  const reload = () => {
-    if (isFailure(liveLoadingState)) {
-      reloadLive();
-    }
-    if (isFailure(charactersLoadingState)) {
-      reloadCharacters();
-    }
-  };
 
   return (
     <>
@@ -30,10 +21,10 @@ const LiveContainer: React.FC = () => {
         />
       </Helmet>
       <div className="content">
-        {isSuccess(liveLoadingState) && isSuccess(charactersLoadingState)
-          ? <Live live={liveLoadingState.data} characters={charactersLoadingState.data} loadTick={lastLoad} />
-          : isFailure(liveLoadingState) || isFailure(charactersLoadingState)
-            ? <Error onTryAgain={reload} />
+        {isSuccess(liveLoadingState)
+          ? <Live live={liveLoadingState.data} loadTick={lastLoad} />
+          : isFailure(liveLoadingState)
+            ? <Error onTryAgain={reloadLive} />
             : <Loading />
          }
       </div>

--- a/frontend/src/hooks.tsx
+++ b/frontend/src/hooks.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useSearchParams, NavigateOptions  } from 'react-router-dom';
 import { useCss } from 'react-use';
+import { useDebounce } from 'react-use';
 
 import tinycolor from 'tinycolor2';
 
@@ -101,3 +102,11 @@ export function useWrappedRefWithWarning(ref: any, componentName: any): any {
   // Yeahhh... about that warning...
   return ref;
 }
+
+export function useDebouncedValue<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useDebounce(() => {
+    setDebounced(value);
+  }, ms, [value]);
+  return debounced;
+};


### PR DESCRIPTION
* Don't load character data until it's needed (i.e. until a search query is first entered)
* Memoize a bunch of the filtering on Live
* Limit the number of offline streams shown (e.g. instead of a search for `a` showing 800+ characters, arbitrarily limit it to the first 50)